### PR TITLE
Fix typo on site.hs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ hakyll $ do
         route idRoute
         compile $ loadImage 
             >>= resizeImageCompiler 64 48
-            >>= compressJpg 50
+            >>= compressJpgCompiler 50
 
     -- Scale images to fit within a 600x400 box
     -- Aspect ratio will be preserved


### PR DESCRIPTION
The `Compiler` postfix was missing on the `compressJpgCompiler` example