### PR TITLE
Add webp reencoder

### DIFF
--- a/hakyll-images.cabal
+++ b/hakyll-images.cabal
@@ -32,6 +32,7 @@ library
   exposed-modules:
       Hakyll.Images
       Hakyll.Images.CompressJpg
+      Hakyll.Images.CompressWebp
       Hakyll.Images.Internal
       Hakyll.Images.Resize
       Hakyll.Images.Metadata
@@ -49,6 +50,7 @@ library
     , bytestring        >= 0.9  && <1
     , hakyll            >  4    && <5
     , vector            >= 0.12 && <0.14
+    , webp              >= 0.1  && <0.2
   default-language: Haskell2010
 
 test-suite spec
@@ -57,6 +59,7 @@ test-suite spec
   other-modules:
       Hakyll.Images.Common.Tests
       Hakyll.Images.CompressJpg.Tests
+      Hakyll.Images.CompressWebp.Tests
       Hakyll.Images.Metadata.Tests
       Hakyll.Images.Resize.Tests
       Hakyll.Images.Tests.Utils

--- a/library/Hakyll/Images.hs
+++ b/library/Hakyll/Images.hs
@@ -59,6 +59,9 @@ module Hakyll.Images
     -- Jpg compression
     JpgQuality,
     compressJpgCompiler,
+    -- Webp compression
+    WebpQuality,
+    compressWebpCompiler,
     -- Image scaling
     Width,
     Height,
@@ -73,5 +76,6 @@ where
 
 import Hakyll.Images.Common
 import Hakyll.Images.CompressJpg
+import Hakyll.Images.CompressWebp
 import Hakyll.Images.Metadata
 import Hakyll.Images.Resize

--- a/library/Hakyll/Images/Common.hs
+++ b/library/Hakyll/Images/Common.hs
@@ -31,6 +31,7 @@ import Codec.Picture.Saving.WithMetadata
   ( imageToBitmapWithMetadata,
     imageToJpgWithMetadata,
     imageToPngWithMetadata,
+    imageToWebp,
   )
 import Codec.Picture.Types (DynamicImage)
 import Data.Bifunctor (second)
@@ -53,6 +54,7 @@ data ImageFormat
   | Bitmap
   | Tiff
   | Gif
+  | Webp
   deriving (Eq, Generic)
 
 -- Automatic derivation of Binary instances requires Generic
@@ -144,6 +146,7 @@ encode Png (MkWithMetadata im meta) = Image Png $ (toStrict . imageToPngWithMeta
 encode Bitmap (MkWithMetadata im meta) = Image Bitmap $ (toStrict . imageToBitmapWithMetadata meta) im
 encode Tiff (MkWithMetadata im _) = Image Tiff $ (toStrict . imageToTiff) im
 encode Gif (MkWithMetadata im _) = Image Gif $ (toStrict . fromRight (error "Could not parse gif") . imageToGif) im
+encode Webp (MkWithMetadata im _) = Image Webp $ imageToWebp 100 im
 
 -- | Map over the content of an `Image`, decoded into an `ImageContent`.
 withImageContent ::

--- a/library/Hakyll/Images/CompressWebp.hs
+++ b/library/Hakyll/Images/CompressWebp.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module      : Hakyll.Images.CompressWebp
+-- Description : Hakyll compiler to compress WebP images
+-- Copyright   : (c) Laurent P René de Cotret, 2019 - present
+-- License     : BSD3
+-- Maintainer  : laurent.decotret@outlook.com
+-- Stability   : unstable
+-- Portability : portable
+--
+-- This module defines a Hakyll compiler, 'compressWebpCompiler', which can be used to
+-- re-encode images to WebP at a lower quality during website compilation. Original images are
+-- left unchanged, but compressed images can be up to 10x smaller.
+--
+-- The @compressWebpCompiler@ is expected to be used like this:
+--
+-- @
+--     import Hakyll
+--     import Hakyll.Images        ( loadImage
+--                                 , compressWebpCompiler
+--                                 )
+--
+--     hakyll $ do
+--
+--         -- Compress all source WebPs to a WebP quality of 50
+--         match "images/**.png" $ do
+--             route idRoute
+--             compile $ loadImage
+--                 >>= compressWebpCompiler 50
+--
+--         (... omitted ...)
+-- @
+module Hakyll.Images.CompressWebp
+  ( WebpQuality,
+    compressWebpCompiler,
+  )
+where
+
+import Codec.Picture.Saving.WithMetadata (imageToWebp)
+import Hakyll.Core.Compiler (Compiler)
+import Hakyll.Core.Item (Item (..))
+import Hakyll.Images.Common
+  ( Image (..),
+    ImageContent,
+    ImageFormat (..),
+    WithMetadata (..),
+    withImageContent,
+  )
+import Foreign.C.Types (CFloat (..))
+
+-- | WebP encoding quality, from 0 (lower quality) to 100 (best quality).
+-- @since 1.2.0
+newtype WebpQuality = WebpQuality Float
+  deriving (Num, Eq, Ord, Real)
+
+-- | @WebpQuality@ smart constructor. Ensures that @WebpQuality@ is always
+-- in the interval [0, 100]. Numbers outside this range will result in either
+-- a quality of 0 or 100.
+--
+-- @since 1.2.0
+mkWebpQuality :: Float -> WebpQuality
+mkWebpQuality q
+  | q < 0 = WebpQuality 0
+  | q > 100 = WebpQuality 100
+  | otherwise = WebpQuality q
+
+-- | Compiler that recompresses an image to a WebP image with a certain quality
+-- setting. The quality should be between 0 (lowest quality) and 100 (best
+-- quality). Values outside of this range will be normalized to the interval
+-- [0, 100]. An error is raised if the image cannot be decoded.
+--
+-- @
+-- match "*.png" $ do
+--    route idRoute
+--    compile $ loadImage >>= compressWebpCompiler 50
+-- @
+compressWebpCompiler :: Float -> Item Image -> Compiler (Item Image)
+compressWebpCompiler quality =
+  return . fmap (withImageContent id encoder)
+  where
+    validatedQuality :: CFloat
+    validatedQuality =
+      let WebpQuality float = mkWebpQuality quality
+      in CFloat float
+
+    encoder :: ImageFormat -> ImageContent -> Image
+    encoder _ (MkWithMetadata d _) =
+      Image Webp $ imageToWebp validatedQuality d

--- a/tests/Hakyll/Images/CompressWebp/Tests.hs
+++ b/tests/Hakyll/Images/CompressWebp/Tests.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hakyll.Images.CompressWebp.Tests
+  ( tests,
+  )
+where
+
+import qualified Data.ByteString as B
+import Hakyll (Identifier, Item (..))
+import Hakyll.Images.Internal (Image (Image, image), ImageFormat (Jpeg), loadImage)
+import Hakyll.Images.CompressWebp (compressWebpCompiler)
+import Hakyll.Images.Tests.Utils (testCompilerDone)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, testCase)
+import Text.Printf (printf)
+
+testJpg :: IO Image
+testJpg = Image Jpeg <$> B.readFile "tests/data/piccolo.jpg"
+
+fromAssertions ::
+  -- | Name
+  String ->
+  -- | Cases
+  [Assertion] ->
+  -- | Result tests
+  [TestTree]
+fromAssertions name =
+  zipWith testCase [printf "[%2d] %s" n name | n <- [1 :: Int ..]]
+
+compressWebp :: Float -> Identifier -> IO Image
+compressWebp quality idt = testCompilerDone idt $ do
+  Item _ compressed <- loadImage >>= compressWebpCompiler quality
+  return $ compressed
+
+-- Test that the standard Image compressed to quality 25/100 is smaller
+-- than the initial image
+testCompressionFromImage :: Assertion
+testCompressionFromImage = do
+  im <- testJpg
+  let initialSize = (B.length . image) im
+  finalSize <- do
+    testCompilerDone "piccolo.jpg" $ do
+      Item _ compressed <- loadImage >>= compressWebpCompiler 25
+      return $ (B.length . image) compressed
+
+  assertBool "Image was not compressed" (initialSize > finalSize)
+
+-- Test that specifying a WebP encoding below 0 will not fail
+testWebpEncodingOutOfLowerBound :: Assertion
+testWebpEncodingOutOfLowerBound = do
+  compressedSize <- B.length . image <$> compressWebp (-10) "piccolo.jpg"
+  expectedSize <- B.length . image <$> compressWebp 0 "piccolo.jpg"
+
+  assertBool "Out-of-bounds WebpQuality was not handled properly" (expectedSize == compressedSize)
+
+-- Test that specifying a WebP encoding above 100 will fail
+testWebpEncodingOutOfUpperBound :: Assertion
+testWebpEncodingOutOfUpperBound = do
+  compressedSize <- B.length . image <$> compressWebp 150 "piccolo.jpg"
+  expectedSize <- B.length . image <$> compressWebp 100 "piccolo.jpg"
+
+  assertBool "Out-of-bounds WebpQuality was not handled properly" (expectedSize == compressedSize)
+
+tests :: TestTree
+tests =
+  testGroup "Hakyll.Images.CompressWebp.Tests" $
+    fromAssertions
+      "compressWebp"
+      [ testCompressionFromImage,
+        testWebpEncodingOutOfLowerBound,
+        testWebpEncodingOutOfUpperBound
+      ]

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -10,6 +10,7 @@ where
 
 import qualified Hakyll.Images.Common.Tests
 import qualified Hakyll.Images.CompressJpg.Tests
+import qualified Hakyll.Images.CompressWebp.Tests
 import qualified Hakyll.Images.Metadata.Tests
 import qualified Hakyll.Images.Resize.Tests
 import qualified Hakyll.Images.Tests.Utils
@@ -23,6 +24,7 @@ main = do
       "Hakyll"
       [ Hakyll.Images.Common.Tests.tests,
         Hakyll.Images.CompressJpg.Tests.tests,
+        Hakyll.Images.CompressWebp.Tests.tests,
         Hakyll.Images.Resize.Tests.tests,
         Hakyll.Images.Metadata.Tests.tests
       ]


### PR DESCRIPTION
Adds `webp` as a dependency, which requires libwebp, since juicy pixels doesn't support webp itself. WebP has widespread support and can be lossy like jpeg, but has better compression and supports transparency.

Basically copied and modified the jpeg-compression module to emit webp instead. Some parts of the code (`imageToWebp`) could be moved around, but I wanted to minimize the diff firstly.

Webp as an input is not supported, so the test uses a jpeg image still. I don't keep my images as webp anyway.